### PR TITLE
New minimum image width in downscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The parameters `provider`, `message`, `max_tokens`, `image_file` and `temperatur
 
 Optionally, the `model`, `target_width` and `detail` properties can be set.  
 - For available **models** check these pages: [supported models for OpenAI](https://platform.openai.com/docs/models) and [LocalAI model gallery](https://localai.io/models/).
-- The **target_width** is an integer between 640 and 3840 representing the image width in pixels. It is used to downscale the image before encoding it.
+- The **target_width** is an integer between 512 and 3840 representing the image width in pixels. It is used to downscale the image before encoding it.
 - The **detail** parameter can be set to `low` or `high`. If it is not set, it is set to 'auto'. OpenAI will then use the image size to determine the detail level. For more information check the [OpenAI documentation](https://platform.openai.com/docs/guides/vision/low-or-high-fidelity-image-understanding).
 ## How to report a bug or request a feature
 > [!NOTE]

--- a/custom_components/gpt4vision/services.yaml
+++ b/custom_components/gpt4vision/services.yaml
@@ -48,7 +48,7 @@ image_analyzer:
       default: 1280
       selector:
         number:
-          min: 640
+          min: 512
           max: 3840
     detail:
       required: false


### PR DESCRIPTION
Images can now be downscaled to 512px, closes #9